### PR TITLE
Fix missing props on BlogPreviewSection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,10 @@ export default function Home() {
       <HowItWorksSection />
       <AIWorkflowSection />
       <CaseStudiesSection />
-      <BlogPreviewSection />
+      <BlogPreviewSection
+        title="From the Blog"
+        description="Latest insights and updates from our team"
+      />
       <CTASection />
     </>
   )


### PR DESCRIPTION
## Summary
- pass title and description to `BlogPreviewSection` on home page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852365ec654832ea1346255f20779e3